### PR TITLE
Prevent exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.7.5
+
+* [budgfix] Handle `self.submitStore` and `self.resultStore` properly on shutdown in AbstractActionWebSocketHandler.
+  They might not have been initialized at all when startup fails.
+
 # v4.7.4
 
 * [bugfix] Catch 401 when using PasswordAuthTokenHandler and refresh_token.

--- a/src/hiro_graph_client/actionwebsocket.py
+++ b/src/hiro_graph_client/actionwebsocket.py
@@ -488,8 +488,8 @@ class AbstractActionWebSocketHandler(AbstractAuthenticatedWebSocketHandler):
     A handler for actions
     """
 
-    submitStore: ActionStore
-    resultStore: ActionStore
+    submitStore: ActionStore = None
+    resultStore: ActionStore = None
 
     def __init__(self,
                  api_handler: AbstractTokenApiHandler,
@@ -509,8 +509,10 @@ class AbstractActionWebSocketHandler(AbstractAuthenticatedWebSocketHandler):
         self.resultStore = ActionStore()
 
     def __del__(self):
-        self.submitStore.stop_scheduler()
-        self.resultStore.stop_scheduler()
+        if self.submitStore:
+            self.submitStore.stop_scheduler()
+        if self.resultStore:
+            self.resultStore.stop_scheduler()
 
     def __finish_submit(self, action_id: str, action_handler_result: Optional[ActionHandlerResult]):
         """


### PR DESCRIPTION
* Handle submitStore and resultStore properly on shutdown. They might not
  have been initialized at all.