### PR TITLE
Changes auth api 6.6

### DIFF
--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -941,12 +941,23 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
 
     def decode_token(self) -> dict:
         """
-        Return a dict with the decoded token payload. This payload contains detailed information about what this token
-        has access to.
+        Return a dict with the decoded token payload from the internal token. This payload contains detailed
+        information about what this token has access to.
 
         :return: The dict with the decoded token payload.
         """
-        base64_payload: list = self.token.split('.')
+        return AbstractTokenApiHandler.get_token_data(self.token)
+
+    @staticmethod
+    def get_token_data(token: str):
+        """
+        Return a dict with the decoded token payload. This payload contains detailed information about what this token
+        has access to.
+
+        :param token: The token to decode.
+        :return: The dict with the decoded token payload.
+        """
+        base64_payload: list = token.split('.')
         if len(base64_payload) == 1:
             raise AuthenticationTokenError("Token is missing base64 payload")
 

--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -946,7 +946,7 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
         return AbstractTokenApiHandler.decode_token_ext(self.token)
 
     @staticmethod
-    def decode_token_ext(token: str):
+    def decode_token_ext(token: str) -> dict:
         """
         Return a dict with the decoded token payload. This payload contains detailed information about what this token
         has access to.
@@ -963,7 +963,7 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
 
         json_payload = base64.urlsafe_b64decode(payload)
 
-        return json.loads(json_payload)
+        return dict(json.loads(json_payload))
 
     @abstractmethod
     def refresh_token(self) -> None:

--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -13,7 +13,6 @@ from urllib.parse import quote, urlencode
 import backoff
 import requests
 import requests.adapters
-import requests.packages.urllib3.exceptions
 
 from hiro_graph_client.version import __version__
 
@@ -191,9 +190,6 @@ class AbstractAPI:
         self._headers = AbstractAPI._merge_headers(initial_headers, headers)
 
         self.ssl_config = ssl_config or SSLConfig()
-
-        if not self.ssl_config.verify:
-            requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
         self._proxies = proxies
         self._raise_exceptions = raise_exceptions
@@ -947,10 +943,10 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
         :return: The dict with the decoded token payload.
         :raises AuthenticationTokenError: When the token does not contain the base64 encoded data payload.
         """
-        return AbstractTokenApiHandler.get_token_data(self.token)
+        return AbstractTokenApiHandler.decode_token_ext(self.token)
 
     @staticmethod
-    def get_token_data(token: str):
+    def decode_token_ext(token: str):
         """
         Return a dict with the decoded token payload. This payload contains detailed information about what this token
         has access to.

--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -956,6 +956,7 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
 
         :param token: The token to decode.
         :return: The dict with the decoded token payload.
+        :raises AuthenticationTokenError: When the token does not contain the base64 encoded data payload.
         """
         base64_payload: list = token.split('.')
         if len(base64_payload) == 1:

--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -945,6 +945,7 @@ class AbstractTokenApiHandler(GraphConnectionHandler):
         information about what this token has access to.
 
         :return: The dict with the decoded token payload.
+        :raises AuthenticationTokenError: When the token does not contain the base64 encoded data payload.
         """
         return AbstractTokenApiHandler.get_token_data(self.token)
 

--- a/src/hiro_graph_client/requirements.txt
+++ b/src/hiro_graph_client/requirements.txt
@@ -1,7 +1,7 @@
-requests~=2.25.1
-backoff~=1.10.0
+requests==2.27.1
+backoff==2.0.1
 
 
-setuptools~=56.1.0
-websocket-client~=0.59.0
-apscheduler~=3.7.0
+setuptools==62.1.0
+websocket-client==1.3.2
+apscheduler==3.9.1

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_cli = true


### PR DESCRIPTION
* Ability to revoke a token.
* Recognize "access_token" and "_TOKEN" in token results.
* Remove obsolete method fresh() from class TokenInfo because
  each token refresh issues a new refresh_token by default now.