### PR TITLE
Org switch and code flow

### DIFF
--- a/src/hiro_graph_client/__init__.py
+++ b/src/hiro_graph_client/__init__.py
@@ -9,8 +9,8 @@ from hiro_graph_client.authclient import HiroAuth
 from hiro_graph_client.authzclient import HiroAuthz
 from hiro_graph_client.client import HiroGraph
 from hiro_graph_client.clientlib import AbstractTokenApiHandler, GraphConnectionHandler, AuthenticationTokenError, \
-    FixedTokenError, TokenUnauthorizedError, PasswordAuthTokenApiHandler, FixedTokenApiHandler, \
-    EnvironmentTokenApiHandler, SSLConfig
+    FixedTokenError, TokenUnauthorizedError, PasswordAuthTokenApiHandler, CodeFlowAuthTokenApiHandler, \
+    FixedTokenApiHandler, EnvironmentTokenApiHandler, SSLConfig
 from hiro_graph_client.iamclient import HiroIam
 from hiro_graph_client.kiclient import HiroKi
 from hiro_graph_client.variablesclient import HiroVariables
@@ -20,9 +20,9 @@ this_directory = path.abspath(path.dirname(__file__))
 
 __all__ = [
     'HiroGraph', 'HiroAuth', 'HiroApp', 'HiroIam', 'HiroKi', 'HiroAuthz', 'HiroVariables', 'GraphConnectionHandler',
-    'AbstractTokenApiHandler', 'PasswordAuthTokenApiHandler', 'FixedTokenApiHandler', 'EnvironmentTokenApiHandler',
-    'AuthenticationTokenError', 'FixedTokenError', 'TokenUnauthorizedError', '__version__',
-    'SSLConfig'
+    'AbstractTokenApiHandler', 'PasswordAuthTokenApiHandler', 'CodeFlowAuthTokenApiHandler', 'FixedTokenApiHandler',
+    'EnvironmentTokenApiHandler', 'AuthenticationTokenError', 'FixedTokenError', 'TokenUnauthorizedError',
+    '__version__', 'SSLConfig'
 ]
 
 site.addsitedir(this_directory)

--- a/src/hiro_graph_client/clientlib.py
+++ b/src/hiro_graph_client/clientlib.py
@@ -1662,9 +1662,6 @@ class CodeFlowAuthTokenApiHandler(AbstractRemoteTokenApiHandler):
         self._scope = scope
         self._redirect_uri = redirect_uri
 
-        self._state = secrets.token_urlsafe(16)
-        self._code_verifier = pkce.generate_code_verifier(length=64)
-
     def get_authorize_uri(self) -> str:
         """
         Construct an authorization uri for your browser.
@@ -1675,6 +1672,10 @@ class CodeFlowAuthTokenApiHandler(AbstractRemoteTokenApiHandler):
             raise AuthenticationTokenError("redirect_uri is missing", 400)
 
         url = self.endpoint + "/authorize"
+
+        # Initialize state and code_verifier anew with each call.
+        self._state = secrets.token_urlsafe(16)
+        self._code_verifier = pkce.generate_code_verifier(length=64)
 
         data = {
             "response_type": "code",

--- a/src/hiro_graph_client/requirements.txt
+++ b/src/hiro_graph_client/requirements.txt
@@ -5,3 +5,4 @@ backoff==2.0.1
 setuptools==62.1.0
 websocket-client==1.3.2
 apscheduler==3.9.1
+pkce==1.0.3

--- a/src/setup.py
+++ b/src/setup.py
@@ -31,7 +31,8 @@ setup(
         'requests',
         'backoff',
         'websocket-client',
-        'apscheduler'
+        'apscheduler',
+        'pkce'
     ],
     package_data={
         name: ['VERSION']

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,40 +1,106 @@
-from hiro_graph_client import PasswordAuthTokenApiHandler, HiroGraph, SSLConfig, GraphConnectionHandler
-from .testconfig import CONFIG
+import base64
+import gzip
+import json
+
+from hiro_graph_client import CodeFlowAuthTokenApiHandler, PasswordAuthTokenApiHandler, SSLConfig, \
+    GraphConnectionHandler, HiroApp, HiroAuth
+from .testconfig import CONFIG_STAGE as CONFIG
 
 
 class TestClient:
+
     connection_handler = GraphConnectionHandler(
         root_url=CONFIG.get('URL'),
         ssl_config=SSLConfig(verify=False)
     )
 
-    hiro_api_handler = PasswordAuthTokenApiHandler(
-        username=CONFIG.get('USERNAME'),
-        password=CONFIG.get('PASSWORD'),
-        client_id=CONFIG.get('CLIENT_ID'),
-        client_secret=CONFIG.get('CLIENT_SECRET'),
-        secure_logging=False,
-        connection_handler=connection_handler
-    )
+    def test_download_config(self):
+        hiro_api_handler = PasswordAuthTokenApiHandler(
+            username=CONFIG.get('USERNAME'),
+            password=CONFIG.get('PASSWORD'),
+            client_id=CONFIG.get('CLIENT_ID'),
+            client_secret=CONFIG.get('CLIENT_SECRET'),
+            secure_logging=False,
+            connection_handler=self.connection_handler
+        )
 
-    hiro_api_handler2 = PasswordAuthTokenApiHandler(
-        username=CONFIG.get('USERNAME'),
-        password=CONFIG.get('PASSWORD'),
-        client_id=CONFIG.get('CLIENT_ID'),
-        client_secret=CONFIG.get('CLIENT_SECRET'),
-        secure_logging=False,
-        connection_handler=connection_handler
-    )
+        hiro_app: HiroApp = HiroApp(api_handler=hiro_api_handler)
+
+        result = hiro_app.get_config()
+
+        content = result.get("content")
+        content_type = result.get("type")
+
+        content_bytes = base64.b64decode(content) if "base64" in content_type else bytearray(content, encoding='utf8')
+
+        config_data = str(gzip.decompress(content_bytes), encoding='utf8') if "gz" in content_type else str(
+            content_bytes, encoding='utf8')
+
+        with open("connector.conf", "w") as file:
+            print(config_data, file=file)
+
+    def test_connect(self):
+        hiro_api_handler = PasswordAuthTokenApiHandler(
+            username=CONFIG.get('USERNAME'),
+            password=CONFIG.get('PASSWORD'),
+            client_id=CONFIG.get('CLIENT_ID'),
+            client_secret=CONFIG.get('CLIENT_SECRET'),
+            secure_logging=False,
+            connection_handler=self.connection_handler
+        )
+
+        hiro_auth: HiroAuth = HiroAuth(api_handler=hiro_api_handler)
+
+        print(json.dumps(hiro_auth.get_identity(), indent=2))
+
+    def test_refresh_token(self):
+        hiro_api_handler = PasswordAuthTokenApiHandler(
+            username=CONFIG.get('USERNAME'),
+            password=CONFIG.get('PASSWORD'),
+            client_id=CONFIG.get('CLIENT_ID'),
+            client_secret=CONFIG.get('CLIENT_SECRET'),
+            secure_logging=False,
+            connection_handler=self.connection_handler
+        )
+
+        handler = hiro_api_handler
+
+        handler.get_token()
+        handler.refresh_token()
+
+        hiro_auth: HiroAuth = HiroAuth(api_handler=handler)
+
+        print(json.dumps(hiro_auth.get_identity(), indent=2))
+
+        handler.revoke_token()
+
+        print(json.dumps(hiro_auth.get_identity(), indent=2))
+
+    def test_auth_code_flow(self):
+        hiro_api_handler = CodeFlowAuthTokenApiHandler(
+            client_id=CONFIG.get('CLIENT_ID'),
+            code='4b12c5f1-cdd7-3487-a5b0-82305b011b67',
+            code_verifier='BQ3kyADe6RKYHttFwGPwvLrX_B6zwCr2vNRe00TQLfoRo-HYhUqM8sPKUQlkhbwUQxli2ZneFhFqx4xbltI4WQ',
+            redirect_uri='http://wksw-whuebner.arago.de:8080/oauth2/app/callback.xhtml',
+            secure_logging=False,
+            connection_handler=self.connection_handler
+        )
+
+        hiro_api_handler.get_token()
+        print(json.dumps(hiro_api_handler.decode_token(), indent=2))
+
+        hiro_api_handler.refresh_token()
+        print(json.dumps(hiro_api_handler.decode_token(), indent=2))
 
     def test_simple_query(self):
-        hiro_client: HiroGraph = HiroGraph(api_handler=self.hiro_api_handler)
-
-        hiro_client.get_node(node_id="ckqjkt42s0fgf0883pf0cb0hx_ckqjl014l0hvr0883hxcvmcwq", meta=True)
-
-        hiro_client: HiroGraph = HiroGraph(api_handler=self.hiro_api_handler2)
-
-        hiro_client.get_node(node_id="ckqjkt42s0fgf0883pf0cb0hx_ckqjl014l0hvr0883hxcvmcwq", meta=True)
-
+        # hiro_client: HiroGraph = HiroGraph(api_handler=self.hiro_api_handler)
+        #
+        # hiro_client.get_node(node_id="ckqjkt42s0fgf0883pf0cb0hx_ckqjl014l0hvr0883hxcvmcwq", meta=True)
+        #
+        # hiro_client: HiroGraph = HiroGraph(api_handler=self.hiro_api_handler2)
+        #
+        # hiro_client.get_node(node_id="ckqjkt42s0fgf0883pf0cb0hx_ckqjl014l0hvr0883hxcvmcwq", meta=True)
+        #
         # def query(_id: str):
         #     hiro_client.get_node(node_id=_id)
         #
@@ -45,3 +111,4 @@ class TestClient:
         # t1.start()
         # t2.start()
         # t3.start()
+        pass


### PR DESCRIPTION
* Added CodeFlowAuthTokenApiHandler to obtain a token via OAuth2 authorization code.
* Added organization and organization_id to token and refresh_token requests.
* Added header handling to all HTTP calls. Make sure, that parameter content_type and keys in header dict do not collide.