### PR TITLE
Add manual triggers for CI actions

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,7 @@ name: Publish to PyPI
 on:
   release:
     types: [ created ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This allows us to manually run actions through the GitHub CLI or UI, see [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch)